### PR TITLE
fix(storybook): remove carriage returns

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -18,16 +18,13 @@
 /* eagle sight */
 @font-face {
   font-family: "Eagle Sight";
-  src: url("/fonts/eagleSight/EagleSightRegular.ttf") format("truetype"),
-    url("/fonts/eagleSight/eaglesightregular-webfont.woff") format("woff"),
-    url("/fonts/eagleSight/eaglesightregular-webfont.woff2") format("woff2");
+  src: url("/fonts/eagleSight/EagleSightRegular.ttf") format("truetype"), url("/fonts/eagleSight/eaglesightregular-webfont.woff") format("woff"), url("/fonts/eagleSight/eaglesightregular-webfont.woff2") format("woff2");
 }
 
 /* sherman */
 @font-face {
   font-family: "Sherman";
-  src: url("/fonts/sherman/Sherman-Display.woff") format("woff"),
-    url("/fonts/sherman/Sherman-Display.woff2") format("woff2");
+  src: url("/fonts/sherman/Sherman-Display.woff") format("woff"), url("/fonts/sherman/Sherman-Display.woff2") format("woff2");
 }
 
 @layer base {


### PR DESCRIPTION
Trying to start up storybook:

<img width="2012" alt="storybook-carriage-returns" src="https://github.com/redwoodjs/ticket-badge-app/assets/32992335/acbe85bf-a12a-4feb-a754-107286d6eb82">

resolve-url-loader, which processes the `url(...)` in the font face declarations, can't seem to handle carriage returns (CRs). Without the carriage returns, starts up just fine:

<img width="2012" alt="storybook-no-carriage-returns" src="https://github.com/redwoodjs/ticket-badge-app/assets/32992335/67418e7f-87fc-448d-a068-5f62968bf41d">

I can see if there's some config we can give to resolve-url-loader framework-side.