### PR TITLE
fix(chromatic): add build storybook script for chromatic

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -32,5 +32,8 @@
   },
   "name": "web",
   "private": true,
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "scripts": {
+    "build-storybook": "yarn storybook build --config-dir ../node_modules/@redwoodjs/testing/config/storybook/"
+  }
 }


### PR DESCRIPTION
Chromatic needs to pass flags to the storybook build CLI that the Redwood CLI can't handle. This adds the config dir flag to the storybook CLI so that it still works.